### PR TITLE
Fix for GHC 7.10

### DIFF
--- a/Game.hs
+++ b/Game.hs
@@ -36,9 +36,6 @@ solutions xs =
 combination [] = []
 combination (x:xs) = [(x, x') | x' <- xs] ++ combination xs
 
-
-join sep = foldl1 (\x y -> x ++ sep ++ y)
-
 play :: Game -> [[Expression]]
 play (Game xs _) = solutions $ map Equ xs
 


### PR DESCRIPTION
Game.hs defines (but does not use) `join` which conflicts with the Prelude in GHC 7.10, so I deleted it (seemed the easiest solution).
